### PR TITLE
Issue templates: see expanded commit message

### DIFF
--- a/.github/ISSUE_TEMPLATE/_empty.md
+++ b/.github/ISSUE_TEMPLATE/_empty.md
@@ -1,0 +1,4 @@
+---
+name: Freeform issue
+about: Use this template when other templates won't work for you.
+---

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 A1. Форкніть основне репо _homeworks_ через веб-інтерфейс GitHub
 
 A2. Клонуйте _homeworks fork_ на вашій локальній машині:
-   - `git clone https://github.com/[your-username]/frontend-2022-homeworks.git`
+   - `git clone https://github.com/<your-username>/frontend-2022-homeworks.git`
 
 > Перед будь-якими подальшими операціями переконайтеся, що ви перебуваєте в каталозі локального repo homeworks
 
@@ -194,7 +194,7 @@ A1: Щоб це сталося, треба зробити наступне:
 
 1. Знайди всі вмерджені PR в інших репо, які треба зарахувати, і май лінки на них під рукою.
 1. Відкрий issue в цьому репо скориставшись
-   [шаблоном](https://github.com/kottans/frontend-2022-homeworks/issues/new?template=import-tasks-from-another-repo.md)
+   [шаблоном](https://github.com/kottans/frontend-2022-homeworks/issues/new?template=import-tasks-from-another-repo.md&title=your-github-username:%20Import%20tasks%20from%20another%20homeworks%20repo)
 1. В студентському чаті закинь лінк на issue і попроси менторів врахувати вже раніше прийняті задачі.
 1. Ментори перевірять статус залінкованих PR і навісять відповідні лейбли.
 1. Через деякий час в [статі цього репо](./stats/pr-stats.md) з'являться відповідні записи.


### PR DESCRIPTION
* add _empty.md for freeform issues as GitHub UI is confusing in these regards

* fix link to import task template: add title URL param since title field in template file doesn't work as documented on GitHub --
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository